### PR TITLE
Fixed error in unstakeTokens function

### DIFF
--- a/contracts/TokenFarm.sol
+++ b/contracts/TokenFarm.sol
@@ -102,6 +102,18 @@ contract TokenFarm is Ownable {
         IERC20(_token).transfer(msg.sender, balance);
         stakingBalance[_token][msg.sender] = 0 ;
         uniqueTokensStaked[msg.sender] = uniqueTokensStaked[msg.sender] - 1;
+        if (uniqueTokensStaked[msg.sender] == 0) {
+            for (
+                uint256 stakersIndex = 0;
+                stakersIndex < stakers.length;
+                stakersIndex++
+            ) {
+                if (stakers[stakersIndex] == msg.sender) {
+                    stakers[stakersIndex] = stakers[stakers.length - 1];
+                    stakers.pop();
+                }
+            }
+        }
     }
 
     function updateUniqueTokensStaked(address _user, address _token) internal {


### PR DESCRIPTION
Fixed error that didn't remove users from stakers array. If they stake a token, unstake it, and stake it again, they would appear twice in the stakers array, and therefore receive two times the reward when issueTokens is called.